### PR TITLE
Added Name to Header and Initials in Bubble

### DIFF
--- a/src/components/Dashboard/StudentCard.js
+++ b/src/components/Dashboard/StudentCard.js
@@ -1,12 +1,18 @@
 import React from "react";
 import { Card, Grid, Image, Label } from "semantic-ui-react";
+import { useHistory } from 'react-router-dom';
 import "./StudentCard.css";
 
 const StudentCard = ({ student }) => {
   const { firstName, lastName, sessions, school } = student;
+  let history = useHistory();
+
+  const toSessions = () => {
+    history.push("/sessions");
+  }
 
   return (
-    <Card fluid centered color="black">
+    <Card fluid centered color="black" onClick={toSessions}>
       <Card.Content>
         <Grid>
           <Grid.Row>

--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -27,4 +27,8 @@
   height: 50px;
   border-radius: 100%;
   background-color: purple;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
 }

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,13 +1,15 @@
 import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import Logo from "../assets/small_white_logo.png";
-import { Popup, Button } from "semantic-ui-react";
+import { Popup } from "semantic-ui-react";
+import { Link } from 'react-router-dom';
 
 import "./Navbar.css";
 
 const Navbar = ({ user }) => {
   const signOut = () => {};
-
+  const firstInitial = user ? user.firstName[0] : '';
+  const lastInitial = user ? user.lastName[0] : '';
   return (
     <header className="navbar">
       <img className="navbar-logo" src={Logo} alt="" />
@@ -16,16 +18,14 @@ const Navbar = ({ user }) => {
           {user ? `${user.firstName} ${user.lastName}` : null}
         </span>
         <Popup
-          disabled
           basic
           on="click"
           content={
             <>
-              <Button>Sign Out</Button>
-              <span>Add users to your feed</span>
+              <Link to="/profile">Edit Profile</Link>
             </>
           }
-          trigger={<div className="profile-icon" />}
+          trigger={<div className="profile-icon">{`${firstInitial}${lastInitial}`}</div>}
         />
       </div>
     </header>

--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -86,13 +86,21 @@ function App() {
               {user ? <Dashboard /> : <Redirect to="/login" />}
             </Route>
             <Route path="/profile">
+              {/* TODO: restrict unauthenticated/unauthorized access to profile page */}
+              {/* {user ? <Profile /> : <Redirect to="/login" />} */}
               <Profile />
             </Route>
             <Route path="/Card">
               <StudentCard />
             </Route>
-            <Route path="/sessions">{<Sessions />}</Route>
+            <Route path="/sessions">
+              {/* TODO: restrict unauthenticated/unauthorized access to sessions page */}
+              {/* {user ? <Sessions /> : <Redirect to="/login" />} */}
+              <Sessions />
+            </Route>
             <Route path="/modal">
+              {/* TODO: restrict unauthenticated/unauthorized access to teacher profile modal */}
+              {/* {user ? <ProfileModal /> : <Redirect to="/login" />} */}
               <ProfileModal />
             </Route>
           </Switch>


### PR DESCRIPTION
When you go to type in /profile or /sessions routes in the url bar, the web app reloads and redirects to /dashboard page. 
I think this behavior is fine.

So, to allow navigation to /profile and /sessions, I added Links to the profile and sessions views on the profile button dropdown, and student card,  respectively.


Also, the initials were added to bubble.
