### PR TITLE
Add loading page wherever necessary; Implement private routes

### DIFF
--- a/src/authentication/Login.jsx
+++ b/src/authentication/Login.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Button, Form } from "semantic-ui-react";
 import { useDispatch } from "react-redux";
 import Logo from "../assets/logo.png";
-import HelpModal from "../components/Modals/HelpModal"
+import HelpModal from "../components/Modals/HelpModal";
 
 import * as userActions from "../store/user/actions";
 
@@ -16,12 +16,13 @@ const Login = () => {
 
   const handleSubmit = () => {
     const loginUser = { email, password };
+    dispatch(userActions.setAutoLoginError(null));
     dispatch(userActions.loginUser({ user: loginUser }));
   };
 
   const closeModal = () => {
-    setIsModalOpen(false)
-  }
+    setIsModalOpen(false);
+  };
 
   return (
     <div className="Registration">
@@ -44,10 +45,7 @@ const Login = () => {
               }}
             />
           </Form.Field>
-          <div 
-            className="forgot-password" 
-            onClick={() => setIsModalOpen(true)}
-          >
+          <div className="forgot-password" onClick={() => setIsModalOpen(true)}>
             Forgot Password?
           </div>
           <div className="button-container">
@@ -56,9 +54,9 @@ const Login = () => {
             </Button>
           </div>
         </Form>
-        <HelpModal 
-          isOpen={isModalOpen} 
-          close={closeModal} 
+        <HelpModal
+          isOpen={isModalOpen}
+          close={closeModal}
           category="password"
         />
       </div>

--- a/src/components/LoginRoute.jsx
+++ b/src/components/LoginRoute.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { Route, Redirect } from "react-router-dom";
+
+import Login from "../authentication/Login";
+import Loading from "../pages/Loading";
+import * as userSelectors from "../store/user/selectors";
+
+const LoginRoute = (props) => {
+  const user = useSelector(userSelectors.getUser);
+  const autoLoginError = useSelector(userSelectors.getAutoLoginError);
+
+  const getRendering = () => {
+    if (autoLoginError) return <Login />;
+    return user ? <Redirect to="/dashboard" /> : <Loading />;
+  };
+
+  return <Route {...props}>{getRendering()}</Route>;
+};
+
+export default LoginRoute;

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import Logo from "../assets/small_white_logo.png";
 import { Popup } from "semantic-ui-react";
-import { Link } from 'react-router-dom';
+import { Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import { useDispatch } from "react-redux";
 
@@ -12,8 +12,8 @@ import "./Navbar.css";
 
 const Navbar = ({ user }) => {
   const signOut = () => {};
-  const firstInitial = user ? user.firstName[0] : '';
-  const lastInitial = user ? user.lastName[0] : '';
+  const firstInitial = user ? user.firstName[0] : "";
+  const lastInitial = user ? user.lastName[0] : "";
   const dispatch = useDispatch();
   return (
     <header className="navbar">
@@ -27,14 +27,24 @@ const Navbar = ({ user }) => {
           on="click"
           content={
             <>
-              <Link to="/profile">Edit Profile</Link><br/>
-              <Link className="logout" to="/login" onClick={() => {
-                Cookies.remove("token")
-                dispatch(userActions.logOut());
-              }}>Log Out</Link>
+              <Link to="/profile">Edit Profile</Link>
+              <br />
+              <Link
+                className="logout"
+                to="/login"
+                onClick={() => {
+                  Cookies.remove("token");
+                  dispatch(userActions.logOut());
+                  window.location.reload();
+                }}
+              >
+                Log Out
+              </Link>
             </>
           }
-          trigger={<div className="profile-icon">{`${firstInitial}${lastInitial}`}</div>}
+          trigger={
+            <div className="profile-icon">{`${firstInitial}${lastInitial}`}</div>
+          }
         />
       </div>
     </header>

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { Route, Redirect } from "react-router-dom";
+
+import Loading from "../pages/Loading";
+import * as userSelectors from "../store/user/selectors";
+
+const ProtectedRoute = (props) => {
+  const user = useSelector(userSelectors.getUser);
+  const autoLoginError = useSelector(userSelectors.getAutoLoginError);
+
+  const getRendering = () => {
+    if (autoLoginError) return <Redirect to="/login" />;
+    return user ? props.children : <Loading />;
+  };
+
+  return <Route {...props}>{getRendering()}</Route>;
+};
+
+export default ProtectedRoute;

--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   BrowserRouter as Router,
@@ -7,6 +7,8 @@ import {
   Redirect,
 } from "react-router-dom";
 
+import LoginRoute from "../../components/LoginRoute";
+import ProtectedRoute from "../../components/ProtectedRoute";
 import Registration from "../../authentication/Registration";
 import Login from "../../authentication/Login";
 import ProfileModal from "../../components/Modals/ProfileModal";
@@ -14,7 +16,6 @@ import CreateAmbassadorModal from "../../components/Modals/CreateAmbassadorModal
 import Dashboard from "../../pages/Dashboard";
 import Sessions from "../../pages/Sessions";
 import Profile from "../../pages/Profile";
-import Loading from "../../pages/Loading";
 import StudentCard from "../../components/StudentCard";
 import * as userSelectors from "../../store/user/selectors";
 import * as userActions from "../../store/user/actions";
@@ -46,34 +47,26 @@ function App() {
                 <Registration setRegisterSuccess={setRegisterSuccess} />
               )}
             </Route>
-            <Route path="/login">
+            {/* <Route path="/login">
               {user ? <Redirect to="/dashboard" /> : <Login />}
-            </Route>
-            <Route path="/dashboard">
-              {user ? <Dashboard /> : <Redirect to="/login" />}
-            </Route>
-            <Route path="/profile">
-              {/* TODO: restrict unauthenticated/unauthorized access to profile page */}
-              {/* {user ? <Profile /> : <Redirect to="/login" />} */}
+            </Route> */}
+            <ProtectedRoute path="/dashboard">
+              <Dashboard />
+            </ProtectedRoute>
+            <ProtectedRoute path="/profile">
               <Profile />
-            </Route>
-            <Route path="/Card">
+            </ProtectedRoute>
+            <ProtectedRoute path="/card">
               <StudentCard />
-            </Route>
-            <Route path="/Loading">
-              <Loading />
-            </Route>
-            <Route path="/students/:id/sessions">
-              {/* TODO: restrict unauthenticated/unauthorized access to sessions page */}
-              {/* {user ? <Sessions /> : <Redirect to="/login" />} */}
+            </ProtectedRoute>
+            <ProtectedRoute path="/students/:id/sessions">
               <Sessions />
-            </Route>
-            <Route path="/modal">
-              {/* TODO: restrict unauthenticated/unauthorized access to teacher profile modal */}
-              {/* {user ? <ProfileModal /> : <Redirect to="/login" />} */}
+            </ProtectedRoute>
+            <ProtectedRoute path="/modal">
               <ProfileModal />
               <CreateAmbassadorModal />
-            </Route>
+            </ProtectedRoute>
+            <LoginRoute />
           </Switch>
         </Router>
       </div>

--- a/src/store/user/actionTypes.js
+++ b/src/store/user/actionTypes.js
@@ -18,6 +18,7 @@ export const INITIALIZE_TEACHER = "@@user/initialize_teacher";
 export const UPDATE_TEACHER = "@@user/update_teacher";
 
 export const SET_ERROR = "@@user/set_error";
-export const SET_PASSWORD_ERROR = "@@user/set_password_error"
+export const SET_PASSWORD_ERROR = "@@user/set_password_error";
+export const SET_AUTO_LOGIN_ERROR = "@@user/set_password_error";
 
-export const FETCH_USER = "@@user/fetch_user"
+export const FETCH_USER = "@@user/fetch_user";

--- a/src/store/user/actions.js
+++ b/src/store/user/actions.js
@@ -10,7 +10,8 @@ export const autoLogin = () => action(actionTypes.AUTO_LOGIN);
 
 export const logOut = () => action(actionTypes.LOG_OUT);
 
-export const changePassword = (data) => action(actionTypes.CHANGE_PASSWORD, data);
+export const changePassword = (data) =>
+  action(actionTypes.CHANGE_PASSWORD, data);
 
 export const setAllAmbassadors = (role) =>
   action(actionTypes.SET_ALL_AMBASSADORS, role);
@@ -37,6 +38,10 @@ export const updateTeacher = (data) => action(actionTypes.UPDATE_TEACHER, data);
 
 export const setError = (err) => action(actionTypes.SET_ERROR, err);
 
-export const setPasswordError = (err) => action(actionTypes.SET_PASSWORD_ERROR, err);
+export const setPasswordError = (err) =>
+  action(actionTypes.SET_PASSWORD_ERROR, err);
+
+export const setAutoLoginError = (err) =>
+  action(actionTypes.SET_AUTO_LOGIN_ERROR, err);
 
 export const fetchUser = (data) => action(actionTypes.FETCH_USER, data);

--- a/src/store/user/reducer.js
+++ b/src/store/user/reducer.js
@@ -6,13 +6,14 @@ export const initialState = {
   data: null,
   error: null,
   passwordError: null,
+  autoLoginError: null,
   ambassadorList: [],
   teacherList: [],
 };
 
 const reducerActions = {
   [actionTypes.LOG_OUT]() {
-    return initialState
+    return initialState;
   },
   [actionTypes.SET_USER](state, action) {
     return {
@@ -42,6 +43,12 @@ const reducerActions = {
     return {
       ...state,
       passwordError: action.payload,
+    };
+  },
+  [actionTypes.SET_AUTO_LOGIN_ERROR](state, action) {
+    return {
+      ...state,
+      autoLoginError: action.payload,
     };
   },
 };

--- a/src/store/user/sagas.js
+++ b/src/store/user/sagas.js
@@ -42,7 +42,7 @@ const autoLogin = function* ({ payload }) {
       yield put(actions.setUser(data.user));
     }
   } catch (err) {
-    yield put(actions.setError(err));
+    yield put(actions.setAutoLoginError(err));
   }
 };
 
@@ -55,7 +55,7 @@ const fetchAllAmbassadors = function* () {
     const response = yield call(
       Axios.post,
       backend_url + "/api/users/getAllFromRole",
-      { role: 'ambassador'},
+      { role: "ambassador" },
       headerParams
     );
     if (response.data.success) {
@@ -76,7 +76,7 @@ const fetchAllTeachers = function* () {
     const response = yield call(
       Axios.post,
       backend_url + "/api/users/getAllFromRole",
-      { role: 'teacher'},
+      { role: "teacher" },
       headerParams
     );
     if (response.data.success) {
@@ -160,7 +160,7 @@ const updateTeacher = function* ({ payload }) {
       headerParams
     );
 
-    console.log("in update", response)
+    console.log("in update", response);
     if (response.data.success) {
       yield put(actions.fetchAllTeachers());
     }
@@ -182,13 +182,17 @@ const changePassword = function* ({ payload }) {
       payload,
       headerParams
     );
-    console.log(response.data)
+    console.log(response.data);
     yield put(actions.setPasswordError(response.data));
   } catch {
-    yield put(actions.setPasswordError({success: false, message: "Error changing password. Please try again."}));
+    yield put(
+      actions.setPasswordError({
+        success: false,
+        message: "Error changing password. Please try again.",
+      })
+    );
   }
-    
-}
+};
 
 const fetchUser = function* ({}) {
   try {
@@ -202,14 +206,13 @@ const fetchUser = function* ({}) {
     });
 
     if (data.success) {
-      console.log("data success")
+      console.log("data success");
       yield put(actions.setUser(data.user));
     }
   } catch (err) {
     yield put(actions.setError(err));
   }
 };
-
 
 export default function* UserSaga() {
   yield all([

--- a/src/store/user/selectors.js
+++ b/src/store/user/selectors.js
@@ -1,4 +1,7 @@
 export const getUser = ({ user: { data } }) => data;
-export const getAllAmbassadors = ({user: { ambassadorList } }) => ambassadorList;
-export const getAllTeachers = ({user: { teacherList } }) => teacherList;
-export const getPasswordError = ({user: {passwordError}}) => passwordError;
+export const getAllAmbassadors = ({ user: { ambassadorList } }) =>
+  ambassadorList;
+export const getAllTeachers = ({ user: { teacherList } }) => teacherList;
+export const getPasswordError = ({ user: { passwordError } }) => passwordError;
+export const getAutoLoginError = ({ user: { autoLoginError } }) =>
+  autoLoginError;


### PR DESCRIPTION
- Unauthenticated users can no longer access any of the pages. They are redirected to /login.
- Upon refresh, user sees loading page while user is being retrieved. 
- When logged in users go to / or /login, they see loading page before redirected to /dashboard

